### PR TITLE
Add ListPlugin to enable list formatting in editor

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -14,6 +14,7 @@ import { ScrollPlugin } from './plugins/ScrollPlugin';
 import { MenuPlugin } from './plugins/MenuPlugin';
 import { TablePlugin } from '@lexical/react/LexicalTablePlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
+import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { ImagePlugin } from './plugins/ImagePlugin';
 import { PastePlugin, PasteData } from './plugins/PastePlugin';
 import { PasteSpecialDialog, PasteOption } from '../Dialogs/PasteSpecialDialog';
@@ -191,6 +192,7 @@ function EditorInner({
                 <FloatingToolbarPlugin />
                 <MenuPlugin onFindOpen={onFindOpen} />
                 <TablePlugin />
+                <ListPlugin />
                 <LinkPlugin />
                 <ImagePlugin />
                 <PastePlugin onOpenPasteSpecial={handleOpenPasteSpecial} />


### PR DESCRIPTION
## Summary
Added support for list formatting functionality in the Editor component by integrating Lexical's ListPlugin.

## Changes
- Imported `ListPlugin` from `@lexical/react/LexicalListPlugin`
- Registered `ListPlugin` in the editor's plugin composition

## Details
This change enables users to create and format ordered and unordered lists within the editor. The ListPlugin is a standard Lexical plugin that handles list node creation, manipulation, and keyboard shortcuts for list operations. It's positioned alongside other formatting plugins (TablePlugin, LinkPlugin, ImagePlugin) in the plugin initialization sequence.

https://claude.ai/code/session_01PezgtNASLTPsRCT7w3Q9wy