### PR TITLE
Suppress Android system text selection toolbar in editor

### DIFF
--- a/src/components/Editor/plugins/FloatingToolbarPlugin.tsx
+++ b/src/components/Editor/plugins/FloatingToolbarPlugin.tsx
@@ -55,6 +55,18 @@ export function FloatingToolbarPlugin() {
         );
     }, [editor, updateToolbar]);
 
+    // Suppress the Android system text selection toolbar (ActionMode) so only
+    // the app's custom floating toolbar is displayed when text is selected.
+    useEffect(() => {
+        const preventContextMenu = (e: MouseEvent) => {
+            e.preventDefault();
+        };
+        return editor.registerRootListener((rootElement, prevRootElement) => {
+            prevRootElement?.removeEventListener('contextmenu', preventContextMenu);
+            rootElement?.addEventListener('contextmenu', preventContextMenu);
+        });
+    }, [editor]);
+
     // Position calculation
     useEffect(() => {
         const handleSelectionChange = () => {


### PR DESCRIPTION
## Summary
Added functionality to suppress the Android system text selection toolbar (ActionMode) so that only the app's custom floating toolbar is displayed when text is selected in the editor.

## Key Changes
- Added a new `useEffect` hook in `FloatingToolbarPlugin` that registers a context menu event listener on the editor's root element
- The listener prevents the default context menu behavior, which suppresses the native Android ActionMode toolbar
- Properly handles cleanup by removing the event listener when the root element changes or the component unmounts

## Implementation Details
- Uses `editor.registerRootListener()` to attach/detach the event listener whenever the root element changes
- Prevents the default `contextmenu` event to block the system text selection toolbar
- Ensures proper cleanup of event listeners to avoid memory leaks

https://claude.ai/code/session_01AgnoXEf7ajLaBQ5CaM1TwD