### PR TITLE
Add Android ContentResolver support for content:// URI access

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/appthere/loki/UriPermissionPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/appthere/loki/UriPermissionPlugin.kt
@@ -6,15 +6,20 @@ import android.net.Uri
 import app.tauri.annotation.Command
 import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSArray
+import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
 
 /**
- * Tauri plugin that persists Android content:// URI permissions across app restarts.
+ * Tauri plugin that provides Android content:// URI access via ContentResolver.
  *
- * When a file is opened via the Storage Access Framework (SAF) file picker, Android
- * grants a temporary permission for that content URI. This permission is revoked when
- * the app process is killed. Calling takePersistablePermission saves the permission
- * durably so subsequent sessions can still read the file (e.g., from Recents).
+ * Tauri's plugin-fs uses Rust's std::fs, which cannot open content:// URIs on
+ * Android. This plugin provides three commands that bypass std::fs entirely:
+ *
+ *  - takePersistablePermission: persists SAF URI permissions across app restarts.
+ *  - readUri: reads all bytes from a content:// URI via ContentResolver.
+ *  - writeUri: writes a byte array to a content:// URI via ContentResolver,
+ *              truncating any existing content.
  */
 @TauriPlugin
 class UriPermissionPlugin(private val activity: Activity) : Plugin(activity) {
@@ -40,6 +45,71 @@ class UriPermissionPlugin(private val activity: Activity) : Plugin(activity) {
             invoke.reject(e.message ?: "SecurityException persisting URI permission")
         } catch (e: Exception) {
             invoke.reject(e.message ?: "Failed to persist URI permission")
+        }
+    }
+
+    /**
+     * Read all bytes from a content:// URI using Android's ContentResolver.
+     *
+     * Returns a JSObject `{ bytes: number[] }` where each element is an
+     * unsigned byte value (0–255). The frontend converts this to a Uint8Array.
+     */
+    @Command
+    fun readUri(invoke: Invoke) {
+        val uri = invoke.getArgs().getString("uri")
+        if (uri.isEmpty()) {
+            invoke.reject("Missing uri parameter")
+            return
+        }
+        try {
+            val parsedUri = Uri.parse(uri)
+            val inputStream = activity.contentResolver.openInputStream(parsedUri)
+                ?: run { invoke.reject("Cannot open input stream for URI: $uri"); return }
+            val rawBytes = inputStream.readBytes()
+            inputStream.close()
+
+            val arr = JSArray()
+            for (b in rawBytes) {
+                arr.put(b.toInt() and 0xFF)
+            }
+            val result = JSObject()
+            result.put("bytes", arr)
+            invoke.resolve(result)
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "Failed to read URI")
+        }
+    }
+
+    /**
+     * Write bytes to a content:// URI using Android's ContentResolver.
+     *
+     * Expects `{ uri: string, bytes: number[] }`. Opens the URI in write-truncate
+     * mode ("wt") so any existing content is replaced. The frontend converts a
+     * Uint8Array to a plain number array before invoking this command.
+     */
+    @Command
+    fun writeUri(invoke: Invoke) {
+        val uri = invoke.getArgs().getString("uri")
+        if (uri.isEmpty()) {
+            invoke.reject("Missing uri parameter")
+            return
+        }
+        try {
+            val bytesJson = invoke.getArgs().getJSONArray("bytes")
+            val bytes = ByteArray(bytesJson.length())
+            for (i in 0 until bytesJson.length()) {
+                bytes[i] = (bytesJson.getInt(i) and 0xFF).toByte()
+            }
+
+            val parsedUri = Uri.parse(uri)
+            val outputStream = activity.contentResolver.openOutputStream(parsedUri, "wt")
+                ?: run { invoke.reject("Cannot open output stream for URI: $uri"); return }
+            outputStream.write(bytes)
+            outputStream.flush()
+            outputStream.close()
+            invoke.resolve()
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "Failed to write URI")
         }
     }
 }

--- a/src/lib/hooks/useFileOperations.ts
+++ b/src/lib/hooks/useFileOperations.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { open, save } from '@tauri-apps/plugin-dialog';
-import { readFile, writeFile } from '@tauri-apps/plugin-fs';
-import { openDocument, saveDocument, takePersistableUriPermission } from '../tauri/commands';
+import { readFile } from '@tauri-apps/plugin-fs';
+import { openDocument, saveDocument, takePersistableUriPermission, readContentUri, writeContentUri } from '../tauri/commands';
 import { useDocumentStore } from '../stores/documentStore';
 import { useHistoryStore } from '../stores/historyStore';
 import { useSessionPersistence } from './useSessionPersistence';
@@ -82,7 +82,11 @@ export function useFileOperations() {
                 }
             }
 
-            const fileBytes = await readFile(path);
+            // On Android, plugin-fs uses Rust's std::fs which cannot open content://
+            // URIs. Use the native ContentResolver command for those paths instead.
+            const fileBytes = path.startsWith('content://')
+                ? await readContentUri(path)
+                : await readFile(path);
             const response = await openDocument(path, fileBytes);
 
             setPath(path);
@@ -191,7 +195,7 @@ export function useFileOperations() {
                     currentPath,
                 );
                 if (bytes && currentPath.startsWith('content://')) {
-                    await writeFile(currentPath, bytes);
+                    await writeContentUri(currentPath, bytes);
                 }
             }
 
@@ -235,26 +239,28 @@ export function useFileOperations() {
                 currentPath || undefined,
             );
             if (bytes) {
+                // content:// URI (Android): backend returned bytes instead of writing
+                // to disk. Write them via ContentResolver and persist the permission.
                 if (path.startsWith('content://')) {
-                    // Persist the permission before writing so future sessions can
-                    // still open this file from Recents without a permissions error.
                     try {
                         await takePersistableUriPermission(path);
                     } catch {
                         // Non-fatal: swallow on desktop and non-persistable URIs.
                     }
-                    await writeFile(path, bytes);
+                    await writeContentUri(path, bytes);
                 }
-                setPath(path);
-                await endSession();
-                await startSession(path);
-                addDocument({
-                    path,
-                    name: metadata.title || path.split('/').pop() || 'Untitled',
-                    type: 'text',
-                });
-                markClean();
+                // else: non-content:// path — backend already wrote to disk.
             }
+            // Update app state regardless of which write path was taken.
+            setPath(path);
+            await endSession();
+            await startSession(path);
+            addDocument({
+                path,
+                name: metadata.title || path.split('/').pop() || 'Untitled',
+                type: 'text',
+            });
+            markClean();
         } catch (error) {
             console.error('Failed handling save as dialog:', error);
             notifyError('Failed to save document', error);

--- a/src/lib/session/SessionManager.ts
+++ b/src/lib/session/SessionManager.ts
@@ -131,9 +131,16 @@ export class SessionManager {
      */
     async saveToOriginal(state: DocState): Promise<void> {
         const bytes = await serializeToBytes(state);
-        // Write to original file via Tauri
-        const { writeFile } = await import('@tauri-apps/plugin-fs');
-        await writeFile(this.meta.originalPath, bytes);
+        // Write to original file. On Android, plugin-fs uses Rust's std::fs which
+        // cannot write to content:// URIs; use the native ContentResolver command
+        // for those paths instead.
+        if (this.meta.originalPath.startsWith('content://')) {
+            const { writeContentUri } = await import('../tauri/commands');
+            await writeContentUri(this.meta.originalPath, bytes);
+        } else {
+            const { writeFile } = await import('@tauri-apps/plugin-fs');
+            await writeFile(this.meta.originalPath, bytes);
+        }
         // Keep session current in sync
         await writeCurrentOdt(this.meta.sessionId, bytes);
         this.meta.lastModified = new Date().toISOString();

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -16,6 +16,34 @@ export async function takePersistableUriPermission(uri: string): Promise<void> {
     await invoke('plugin:uriPermission|takePersistablePermission', { uri });
 }
 
+/**
+ * Android only: read all bytes from a content:// URI via Android ContentResolver.
+ *
+ * Tauri's plugin-fs uses Rust's std::fs, which cannot open content:// URIs on
+ * Android. This command goes through the UriPermissionPlugin Kotlin layer which
+ * calls ContentResolver.openInputStream, guaranteeing SAF URI access works.
+ *
+ * On non-Android platforms this will reject; callers must use readFile instead.
+ */
+export async function readContentUri(uri: string): Promise<Uint8Array> {
+    const result: { bytes: number[] } = await invoke('plugin:uriPermission|readUri', { uri });
+    return new Uint8Array(result.bytes);
+}
+
+/**
+ * Android only: write bytes to a content:// URI via Android ContentResolver.
+ *
+ * Tauri's plugin-fs uses Rust's std::fs, which cannot write content:// URIs on
+ * Android. This command goes through the UriPermissionPlugin Kotlin layer which
+ * calls ContentResolver.openOutputStream in write-truncate mode, guaranteeing
+ * SAF URI writes work.
+ *
+ * On non-Android platforms this will reject; callers must use writeFile instead.
+ */
+export async function writeContentUri(uri: string, bytes: Uint8Array): Promise<void> {
+    await invoke('plugin:uriPermission|writeUri', { uri, bytes: Array.from(bytes) });
+}
+
 /** Response from `open_document`: native Lexical editor state + styles + metadata. */
 export interface LexicalResponse {
     content: LexicalDocumentData;


### PR DESCRIPTION
## Summary
This PR adds native Android ContentResolver support to handle `content://` URIs, which cannot be accessed via Tauri's `plugin-fs` (which uses Rust's `std::fs`). The changes introduce two new Kotlin plugin commands and update the frontend to use them when working with Storage Access Framework (SAF) URIs on Android.

## Key Changes

- **UriPermissionPlugin.kt**: Extended the plugin with two new commands:
  - `readUri`: reads all bytes from a `content://` URI via `ContentResolver.openInputStream`
  - `writeUri`: writes bytes to a `content://` URI via `ContentResolver.openOutputStream` in write-truncate mode
  - Updated class documentation to reflect the expanded functionality

- **commands.ts**: Added two new TypeScript command wrappers:
  - `readContentUri(uri)`: invokes the native `readUri` command and converts the result to `Uint8Array`
  - `writeContentUri(uri, bytes)`: invokes the native `writeUri` command with byte array conversion

- **useFileOperations.ts**: Updated file I/O logic to route `content://` URIs through the new ContentResolver commands:
  - `openFile`: uses `readContentUri` for `content://` paths instead of `readFile`
  - `saveDocument`: uses `writeContentUri` for `content://` paths instead of `writeFile`
  - `saveAsDocument`: uses `writeContentUri` for `content://` paths and improved control flow to handle both write paths uniformly

- **SessionManager.ts**: Updated `saveToOriginal` to detect and route `content://` URIs through `writeContentUri`

## Implementation Details

- Byte conversion handles unsigned byte values (0–255) correctly in both directions between Kotlin and TypeScript
- `writeUri` uses write-truncate mode (`"wt"`) to replace existing content
- All new commands include comprehensive JSDoc comments explaining Android-specific behavior
- Error handling is consistent with existing plugin patterns
- The changes are backward compatible; non-Android platforms continue using `plugin-fs`

https://claude.ai/code/session_01J39pMh3ZymXAf9W5K3Ziyi